### PR TITLE
Specify whether GPLv3+ or GPLv3-ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ LICENSE
 =======
 
 The System Shock source code is available under the terms of the GNU
-General Public License v3.0
+General Public License v3.0 or (at your option) any later version.
 
 See COPYING.txt for the GNU GENERAL PUBLIC LICENSE

--- a/README.md
+++ b/README.md
@@ -90,7 +90,19 @@ How to compile:
 LICENSE
 =======
 
-The System Shock source code is available under the terms of the GNU
-General Public License v3.0 or (at your option) any later version.
+Copyright (C) 2015-2018 Night Dive Studios, LLC.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+ 
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+ 
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 See COPYING.txt for the GNU GENERAL PUBLIC LICENSE


### PR DESCRIPTION
It is important to specify that the license is GPL version 3 _or later_, as is the recommendation of GNU (the publishers of the license) shown in the license itself.